### PR TITLE
Update deprecated Call() to current one

### DIFF
--- a/nan_async.cc
+++ b/nan_async.cc
@@ -26,7 +26,7 @@ void Work::Execute () {
 void Work::HandleOKCallback () {
   Nan::HandleScope scope;
   Local<Value> argv[] = { Nan::New<String>(this->data).ToLocalChecked() };
-  this->callback->Call(1, argv);
+  this->callback->Call(1, argv, this->async_resource);
 }
 
 NAN_METHOD (MethodAsync) {


### PR DESCRIPTION
This patch fixes the following warning:
```
../nan_async.cc: In member function ‘virtual void Work::HandleOKCallback()’:
../nan_async.cc:29:31: warning: ‘v8::Local<v8::Value> Nan::Callback::Call(int, v8::Local<v8::Value>*) const’ is deprecated [-Wdeprecated-declarations]
   29 |   this->callback->Call(1, argv);
```